### PR TITLE
setup-error

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
 
     @user = User.new(params.require(:user)
       .permit(:email, :password, :password_confirmation, :cellphone, :token))
-    @user.uuid = session[:user_uuid]
+    @user.uuid = RandomCode.generate_utoken
 
     if @user.save
       flash[:notice] = "注册成功，请登录"


### PR DESCRIPTION
用户在注册以后，如果不登录继续注册，会引发报错，是因为用户不登录session[:user_uuid]就不会更新，在注册时就违背了User.uuid不能重复的原则，所以会报错。